### PR TITLE
genIntStructs and genVappStructs for creating a cell structure containing solutions at a range of illumination intensities or applied voltages

### DIFF
--- a/Driftfusion v1.1/genIntStructs.m
+++ b/Driftfusion v1.1/genIntStructs.m
@@ -1,0 +1,87 @@
+function structCell = genIntStructs(struct_eq, struct_light, startInt, endInt, points)
+%GENINTSTRUCTS - Generates a cell containing structures of solutions at various light intensities
+%
+% Syntax:  structCell = genIntStructs(struct_eq, struct_light, startInt, endInt, points)
+%
+% Inputs:
+%   STRUCT_EQ - a solution struct as created by PINDRIFT in dark conditions, or a logic false for not having the dark.
+%   STRUCT_LIGHT - a solution struct as created by PINDRIFT with 1 sun illumination.
+%   STARTINT - higher requested illumination.
+%   ENDINT - lower requested illumination.
+%   POINTS - number of illumination requested between STARTINT and ENDINT, including extrema, except dark.
+%
+% Outputs:
+%   STRUCTCELL - a cell containing structs of solutions at various light
+%     intensities
+%
+% Example:
+%   genIntStructs(ssol_i_eq, ssol_i_light, 100, 0.1, 4)
+%     prepare solutions at 100, 10, 1, 0.1 and 0 illumination intensities
+%   genIntStructs(false, ssol_i_light, 100, 0.1, 4)
+%     as above but without the solution at 0 illumination (dark)
+%
+% Other m-files required: changeLight, pindrift
+% Subfunctions: none
+% MAT-files required: none
+%
+% See also genVappStructs, changeLight, pindrift.
+
+% Author: Ilario Gelmetti, Ph.D. student, perovskite photovoltaics
+% Institute of Chemical Research of Catalonia (ICIQ)
+% Research Group Prof. Emilio Palomares
+% email address: iochesonome@gmail.com
+% Supervised by: Dr. Phil Calado, Dr. Piers Barnes, Prof. Jenny Nelson
+% Imperial College London
+% October 2017; Last revision: January 2018
+
+%------------- BEGIN CODE --------------
+
+struct_Int = struct_light;
+
+% define light intensity values, always decreasing
+Int_array = logspace(log10(startInt), log10(endInt), points);
+Int_array = [Int_array, 1]; % 1 sun should always be included, it will be always provided in input as second argument
+% if stabilized dark solution is provided in input, calculate the point at dark
+% conditions using that solution
+if isa(struct_eq, 'struct') % dark calculation can be disabled using "false" as first command argument
+    Int_array = [Int_array, 0];
+    % decrease annoiance by figures popping up
+    struct_eq.params.figson = 0;
+end
+
+Int_array = unique(Int_array); % remove duplicates
+Int_array = sort(Int_array, 'descend'); % from high intensity to low, beware to not use changeLight for reaching dark as logspace to zero doesn't work
+
+% pre allocate
+structCell = cell(2, length(Int_array));
+
+existingVars = evalin('base', 'who');
+changeLight_tmax = false; % automatic tmax for the first run
+
+%% generate solutions
+for i = 1:length(Int_array)
+    disp([mfilename ' - illumination intensity ' num2str(Int_array(i))])
+    name = matlab.lang.makeValidName([inputname(2) '_Int_' num2str(Int_array(i))]);
+    if any(strcmp(existingVars, name)) % check if a structure with the same name already exists
+        struct_Int = evalin('base', name);
+    elseif Int_array(i) == 1 % in dark use the symstruct_eq solution, needed for no ions case where changeLight cannot reach dark
+        struct_Int = struct_light;
+    elseif ~Int_array(i)
+        struct_Int = struct_eq;
+        % if none of the previous if conditions is true, just use the
+        % previously set struct_Int
+    end
+    % decrease annoiance by figures popping up
+    struct_Int.params.figson = 0;
+    % in any case (even the one not considered by the if), stabilize at the new intensity
+    struct_Int = changeLight(struct_Int, Int_array(i), changeLight_tmax); % change light intensity
+    changeLight_tmax = max(struct_Int.params.tmax / 5, 1e-8); % time to use for next iteration
+
+    % restore figson before saving
+    struct_Int.params.figson = 1;
+    structCell{1, i} = struct_Int;
+    structCell{2, i} = name;
+    assignin('base', name, struct_Int);
+end
+
+%------------- END OF CODE --------------

--- a/Driftfusion v1.1/genIntStructs.m
+++ b/Driftfusion v1.1/genIntStructs.m
@@ -46,7 +46,7 @@ Int_array = [Int_array, 1]; % 1 sun should always be included, it will be always
 if isa(struct_eq, 'struct') % dark calculation can be disabled using "false" as first command argument
     Int_array = [Int_array, 0];
     % decrease annoiance by figures popping up
-    struct_eq.params.figson = 0;
+    struct_eq.p.figson = 0;
 end
 
 Int_array = unique(Int_array); % remove duplicates
@@ -72,13 +72,13 @@ for i = 1:length(Int_array)
         % previously set struct_Int
     end
     % decrease annoiance by figures popping up
-    struct_Int.params.figson = 0;
+    struct_Int.p.figson = 0;
     % in any case (even the one not considered by the if), stabilize at the new intensity
     struct_Int = changeLight(struct_Int, Int_array(i), changeLight_tmax); % change light intensity
-    changeLight_tmax = max(struct_Int.params.tmax / 5, 1e-8); % time to use for next iteration
+    changeLight_tmax = max(struct_Int.p.tmax / 5, 1e-8); % time to use for next iteration
 
     % restore figson before saving
-    struct_Int.params.figson = 1;
+    struct_Int.p.figson = 1;
     structCell{1, i} = struct_Int;
     structCell{2, i} = name;
     assignin('base', name, struct_Int);

--- a/Driftfusion v1.1/genVappStructs.m
+++ b/Driftfusion v1.1/genVappStructs.m
@@ -36,10 +36,10 @@ function structCell = genVappStructs(asymstruct, startVapp, endVapp, points)
 asymstruct_Vapp = asymstruct;
 
 % estimate a good tmax
-if asymstruct_Vapp.params.mui
-    tmax_temp = 2^(-log10(asymstruct_Vapp.params.mui)) / 10 + 2^(-log10(asymstruct_Vapp.params.mue_i));
+if asymstruct_Vapp.p.mui
+    tmax_temp = 2^(-log10(asymstruct_Vapp.p.mui)) / 10 + 2^(-log10(asymstruct_Vapp.p.mue_i));
 else
-    tmax_temp = 2^(-log10(asymstruct_Vapp.params.mue_i));
+    tmax_temp = 2^(-log10(asymstruct_Vapp.p.mue_i));
 end
 
 % define linearly spaced applied voltage values
@@ -63,9 +63,9 @@ for i = 1:length(Vapp_array)
         % previously set struct_Vapp
     end
     % decrease annoiance by figures popping up
-    asymstruct_Vapp.params.figson = 0;
+    asymstruct_Vapp.p.figson = 0;
     
-    p = asymstruct_Vapp.params;
+    p = asymstruct_Vapp.p;
     % prepare parameters for the voltage change
     p.tmesh_type = 2;
     p.t0 = 1e-10;
@@ -85,7 +85,7 @@ for i = 1:length(Vapp_array)
     asymstruct_Vapp = pindrift(asymstruct_Vapp, p);
 
     % restore figson before saving
-    asymstruct_Vapp.params.figson = 1;
+    asymstruct_Vapp.p.figson = 1;
     structCell{1, i} = asymstruct_Vapp;
     structCell{2, i} = name;
     assignin('base', name, asymstruct_Vapp);

--- a/Driftfusion v1.1/genVappStructs.m
+++ b/Driftfusion v1.1/genVappStructs.m
@@ -1,21 +1,24 @@
-function structCell = genVappStructs(asymstruct, startVapp, endVapp, points)
+function structCell = genVappStructs(asymstruct, Vapp_array)
 %GENVAPPSTRUCTS - Generates a cell containing asymmetric structures of solutions at various applied voltages
 %
 % Syntax:  structCell = genVappStructs(asymstruct, startVapp, endVapp, points)
 %
 % Inputs:
 %   ASYMSTRUCT - a solution asymmetric struct as created by PINDRIFT.
-%   STARTVAPP - higher requested Vapp.
-%   ENDVAPP - lower requested Vapp.
-%   POINTS - number of applied voltages requested between STARTVAPP and ENDVAPP, including extrema.
+%   VAPP_ARRAY - an array containing the requested Vapp list.
 %
 % Outputs:
 %   STRUCTCELL - a cell containing structs of solutions at various applied
-%     voltages
+%     voltages, ordered with ascending voltages
 %
 % Example:
-%   structs_Vapp_dark = genVappStructs(sol_i_eq, 1, 0, 6);
-%     generates dark solutions at 6 different applied voltages
+%   structs_Vapp_dark = genVappStructs(sol_i_eq, 0:0.2:1);
+%     generates dark solutions at 0, 0.2, 0.4, 0.6, 0.8 and 1 V applied voltages
+%   structs_Vapp_dark = genVappStructs(sol_i_eq, linspace(0, 1, 15));
+%     generates dark solutions at 15 different voltages from 0 to 1 V
+%   structs_Vapp_dark = genVappStructs(sol_i_eq, [0, 0.8, 0.9]);
+%     generates dark solutions at a list of applied voltages, remember that
+%     the list will have an ascending ordering in the output structure
 %
 % Other m-files required: pindrift
 % Subfunctions: none
@@ -42,8 +45,6 @@ else
     tmax_temp = min(1, 2^(-log10(asymstruct_Vapp.p.mue_i)));
 end
 
-% define linearly spaced applied voltage values
-Vapp_array = linspace(startVapp, endVapp, points);
 % usually the solution in short circuit is given in input, so start from
 % zero Vapp
 Vapp_array = sort(Vapp_array, 'ascend');

--- a/Driftfusion v1.1/genVappStructs.m
+++ b/Driftfusion v1.1/genVappStructs.m
@@ -1,0 +1,94 @@
+function structCell = genVappStructs(asymstruct, startVapp, endVapp, points)
+%GENVAPPSTRUCTS - Generates a cell containing asymmetric structures of solutions at various applied voltages
+%
+% Syntax:  structCell = genVappStructs(asymstruct, startVapp, endVapp, points)
+%
+% Inputs:
+%   ASYMSTRUCT - a solution asymmetric struct as created by PINDRIFT.
+%   STARTVAPP - higher requested Vapp.
+%   ENDVAPP - lower requested Vapp.
+%   POINTS - number of applied voltages requested between STARTVAPP and ENDVAPP, including extrema.
+%
+% Outputs:
+%   STRUCTCELL - a cell containing structs of solutions at various applied
+%     voltages
+%
+% Example:
+%   structs_Vapp_dark = genVappStructs(sol_i_eq, 1, 0, 6);
+%     generates dark solutions at 6 different applied voltages
+%
+% Other m-files required: pindrift
+% Subfunctions: none
+% MAT-files required: none
+%
+% See also genIntStructs, pindrift.
+
+% Author: Ilario Gelmetti, Ph.D. student, perovskite photovoltaics
+% Institute of Chemical Research of Catalonia (ICIQ)
+% Research Group Prof. Emilio Palomares
+% email address: iochesonome@gmail.com
+% Supervised by: Dr. Phil Calado, Dr. Piers Barnes, Prof. Jenny Nelson
+% Imperial College London
+% October 2017; Last revision: January 2018
+
+%------------- BEGIN CODE --------------
+
+asymstruct_Vapp = asymstruct;
+
+% estimate a good tmax
+if asymstruct_Vapp.params.mui
+    tmax_temp = 2^(-log10(asymstruct_Vapp.params.mui)) / 10 + 2^(-log10(asymstruct_Vapp.params.mue_i));
+else
+    tmax_temp = 2^(-log10(asymstruct_Vapp.params.mue_i));
+end
+
+% define linearly spaced applied voltage values
+Vapp_array = linspace(startVapp, endVapp, points);
+% usually the solution in short circuit is given in input, so start from
+% zero Vapp
+Vapp_array = sort(Vapp_array, 'ascend');
+
+% pre allocate
+structCell = cell(2, length(Vapp_array));
+
+existingVars = evalin('base', 'who');
+
+%% generate solutions
+for i = 1:length(Vapp_array)
+    disp([mfilename ' - applied voltage ' num2str(Vapp_array(i))])
+    name = matlab.lang.makeValidName([inputname(1) '_Vapp_' num2str(Vapp_array(i))]);
+    if any(strcmp(existingVars, name)) % check if a structure with the same name already exists
+        asymstruct_Vapp = evalin('base', name);
+        % if none of the previous if conditions is true, just use the
+        % previously set struct_Vapp
+    end
+    % decrease annoiance by figures popping up
+    asymstruct_Vapp.params.figson = 0;
+    
+    p = asymstruct_Vapp.params;
+    % prepare parameters for the voltage change
+    p.tmesh_type = 2;
+    p.t0 = 1e-10;
+    p.tpoints = 50; % wide, does not matter much but have to be bigger than t_npoints_V_step
+    p.calcJ = 0; % we do not need to calculate current here
+    p.tmax = tmax_temp;
+
+    % ideal sudden change is voltage maybe cannot be solved
+    % boundary conditions have to be changed more slowly 
+    % the solver needs at least one point at the starting voltage, before switching to short circuit
+    p.JV = 2; % new mode for fast Voc changes
+    p.t_npoints_V_step = 10; % new variable for Voc sudden changes, if equals tpoints is like a JV scan, minimum 2 points which is a direct step
+    p.Vstart = asymstruct_Vapp.Efn(end) - asymstruct_Vapp.Efp(1);
+    p.Vend = Vapp_array(i); % final Voc
+
+    % go to the new Vapp
+    asymstruct_Vapp = pindrift(asymstruct_Vapp, p);
+
+    % restore figson before saving
+    asymstruct_Vapp.params.figson = 1;
+    structCell{1, i} = asymstruct_Vapp;
+    structCell{2, i} = name;
+    assignin('base', name, asymstruct_Vapp);
+end
+
+%------------- END OF CODE --------------

--- a/Driftfusion v1.1/genVappStructs.m
+++ b/Driftfusion v1.1/genVappStructs.m
@@ -37,9 +37,9 @@ asymstruct_Vapp = asymstruct;
 
 % estimate a good tmax
 if asymstruct_Vapp.p.mui
-    tmax_temp = 2^(-log10(asymstruct_Vapp.p.mui)) / 10 + 2^(-log10(asymstruct_Vapp.p.mue_i));
+    tmax_temp = min(1e3, 2^(-log10(asymstruct_Vapp.p.mui)) / 10 + 2^(-log10(asymstruct_Vapp.p.mue_i)));
 else
-    tmax_temp = 2^(-log10(asymstruct_Vapp.p.mue_i));
+    tmax_temp = min(1, 2^(-log10(asymstruct_Vapp.p.mue_i)));
 end
 
 % define linearly spaced applied voltage values


### PR DESCRIPTION
This PR depends on *changeLight* #8 and on JV 2 #9 
Some times, writing scripts working on various light intensities or applied DC votages, it's useful to input directly a meta-structure containing all the structures the simulation has to run on. A convenient way to store these structures is in a cell structure.
These scripts take advantage of *changeLight* (in the case of genIntStructs) or directly of pindrift (in the case of genVappStructs) for cleating a cell containing the solutions at the requested illumination intensities or DC voltages.
*genIntStructs* accepts in input a solution in dark (optional), one under illumination a starting and ending point of the illumination range and the number of points.
*genVappStructs* accepts in input a solution at short circuit and an array of voltages to apply.
Please notice that the single solutions gets saved in the workspace and used for having a faster solution on the next run.
