### PR TITLE
asymmetricize verify stabilization, set max time

### DIFF
--- a/Driftfusion v1.1/asymmetricize.m
+++ b/Driftfusion v1.1/asymmetricize.m
@@ -3,14 +3,18 @@ function asymstruct = asymmetricize(symstruct, BC)
 % asymmetrical model at pseudo-OC conditions applying Vapp equal to Voc
 % taken from the symmetrical solution
 %
-% Syntax:  sol = asymmetricize(ssol, BC)
+% Syntax:  asymstruct = asymmetricize(symstruct, BC)
 %
 % Inputs:
-%   SYMSTRUCT - a symmetric struct as created by pindrift using the OC
+%   SYMSTRUCT - a symmetric struct as created by PINDRIFT using the OC
 %     parameter set to 1
+%   BC - boudary conditions to be used for the new solution, as defined in
+%     PINPARAMS and PINDRIFT
 %
 % Outputs:
-%
+%   ASYMSTRUCT - an asymmetric struct as created by PINDRIFT using the OC
+%     parameter set to 0 and applied voltage identical to the open circuit
+%     voltage taken from the input SYMSTRUCT
 %
 % Example:
 %   sol_i_light_OC = asymmetricize(ssol_i_light, 1)
@@ -35,7 +39,8 @@ function asymstruct = asymmetricize(symstruct, BC)
 p = symstruct.p;
 p.OC = 0; % without setting OC to 0 BC gets ignored, OC 0 is needed for the asymmetric solution
 p.BC = BC;
-p.tpoints = 5; % rough, just for re-stabilization at Vapp
+p.tpoints = 10; % rough, just for re-stabilization at Vapp
+p.Ana = 0;
 
 % get the Voc value in the middle of the symmetrical solution at the final time step
 Voc = symstruct.Voc(end);
@@ -43,9 +48,9 @@ p.Vapp = Voc; % use potential value in the middle as new applied voltage, this i
 
 % set an initial time for stabilization tmax
 if p.mui
-    p.tmax = 2^(-log10(p.mui)) / 10 + 2^(-log10(p.mue_i));
+    p.tmax = min(1e1, 2^(-log10(p.mui)) / 10 + 2^(-log10(p.mue_i)));
 else
-    p.tmax = 2^(-log10(p.mue_i));
+    p.tmax = min(1e1, 2^(-log10(p.mue_i)));
 end
 
 %% halve the solution
@@ -54,6 +59,13 @@ sol_ic.sol = symstruct.sol(end, 1:centerIndex, :); % take the first spatial half
 sol_ic.x = symstruct.x(1:centerIndex); % providing just sol to pindrift is not enough, a more complete structure is needed, including at least x mesh
 
 %% stabilize the divided solution
-asymstruct = pindrift(sol_ic, p); % should already be stable...
+asymstruct = pindrift(sol_ic, p); % should already be stable, this run of pindrift should be fast...
+
+warning('off', 'pindrift:verifyStabilization');
+while ~verifyStabilization(asymstruct.sol, asymstruct.t, 1e-3) % check stability in a strict way
+    disp([mfilename ' - Stabilizing over ' num2str(p.tmax) ' s']);
+    asymstruct = pindrift(asymstruct, p);
+end
+warning('on', 'pindrift:verifyStabilization');
 
 %------------- END OF CODE --------------


### PR DESCRIPTION
Asymmetricize can fail if the tmax is too large, so here is limited to an arbitrary value of 10 seconds.

After breaking the solution is not always in the final status: for some unidentified reasons, at OC there is a accumulation or depletion of free charges at the boudaries, depending on the xmesh, as documented in the release notes file. For this reason, checking stabilization can be useful in some cases.