### PR TITLE
Fix number of rows when initialising variables in explore helper

### DIFF
--- a/Helper/explore.m
+++ b/Helper/explore.m
@@ -69,9 +69,9 @@ classdef explore
             
                 Voc_stable = zeros(length(parval2), JVpnts);
                 PLint = zeros(length(parval2), JVpnts);
-                Vapp_f = zeros(1, JVpnts);
+                Vapp_f = zeros(length(parval2), JVpnts);
                 J_f = zeros(length(parval2), JVpnts);
-                Vapp_r = zeros(1, JVpnts);
+                Vapp_r = zeros(length(parval2), JVpnts);
                 J_r = zeros(length(parval2), JVpnts);
                 
                 for j = 1:length(parval2)


### PR DESCRIPTION
When running the `Scripts/explore_script.m`, some of the iterations were failing inside a try and this caused an error in the `AA(i,:,:) = Vapp_f;` assignment due to the variables `Vapp_f` and `Vapp_r` initialized with one only row.
If needed, I can explain better the issue :)