### PR TITLE
df.dfpde faster execution

### DIFF
--- a/Core/df.m
+++ b/Core/df.m
@@ -150,6 +150,9 @@ x_ihalf_padded = [x_ihalf, nan(1,sampling_step-mod(x_ihalf_length,sampling_step)
 x_ihalf_padded_mat = reshape(x_ihalf_padded,sampling_step,[]);
 x_ihalf_sampled = x_ihalf_padded_mat(1,:);
 
+% normalise epp
+epp_norm = epp/eppmax;
+
 % prepare constant generation profiles
 int1gx1 = int1*gx1;
 int2gx2 = int2*gx2;
@@ -236,7 +239,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         dVdx = dudx(1); dndx = dudx(2); dpdx = dudx(3); 
         
         % Flux terms
-        F_potential  = (epp(i)/eppmax)*dVdx;
+        F_potential  = epp_norm(i)*dVdx;
         F_electron   = mue(i)*n*(-dVdx + gradEA(i)) + (Dn(i)*(dndx - ((n/Nc(i))*gradNc(i))));
         F_hole       = muh(i)*p*(dVdx - gradIP(i)) + (Dp(i)*(dpdx - ((p/Nv(i))*gradNv(i))));      
         F = [F_potential; mobset*F_electron; mobset*F_hole]; 

--- a/Core/df.m
+++ b/Core/df.m
@@ -277,13 +277,13 @@ function [C,F,S] = dfpde(x,t,u,dudx)
 
         % F_cation: Flux term for cations
         % dudx(4) is dcdx, gradient of mobile cation concentration
-        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
+        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*dcdx*(1 + c/(DOScat(i)-c)));
 
         if N_ionic_species_two % Condition for anion terms
 
             % F_anion: Flux term for anions
             % dudx(5) is dadx, gradient of mobile anion concentration
-            F_anion = K_anion*mobseti*muani(i)*(a*-dVdx + kBT*(dadx+(a*(dadx/(DOSani(i)-a)))));
+            F_anion = K_anion*mobseti*muani(i)*(a*-dVdx + kBT*dadx*(1 + a/(DOSani(i)-a)));
 
             % F: Flux terms
             F = [F_potential; F_electron; F_hole; F_cation; F_anion];

--- a/Core/df.m
+++ b/Core/df.m
@@ -242,13 +242,10 @@ function [C,F,S] = dfpde(x,t,u,dudx)
 
     if N_ionic_species
             c = u(4);           % Include cation variable
-            dcdx = dudx(4);
             a = Nani(i);
         if N_ionic_species_two
             c = u(4);           % Include cation variable
             a = u(5);           % Include anion variable
-            dcdx = dudx(4);
-            dadx = dudx(5);
         end
     else
         c = Ncat(i);
@@ -277,13 +274,13 @@ function [C,F,S] = dfpde(x,t,u,dudx)
 
         % F_cation: Flux term for cations
         % dudx(4) is dcdx, gradient of mobile cation concentration
-        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*dcdx*(1 + c/(DOScat(i)-c)));
+        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*dudx(4)*(1 + c/(DOScat(i)-c)));
 
         if N_ionic_species_two % Condition for anion terms
 
             % F_anion: Flux term for anions
             % dudx(5) is dadx, gradient of mobile anion concentration
-            F_anion = K_anion*mobseti*muani(i)*(a*-dVdx + kBT*dadx*(1 + a/(DOSani(i)-a)));
+            F_anion = K_anion*mobseti*muani(i)*(a*-dVdx + kBT*dudx(5)*(1 + a/(DOSani(i)-a)));
 
             % F: Flux terms
             F = [F_potential; F_electron; F_hole; F_cation; F_anion];

--- a/Core/df.m
+++ b/Core/df.m
@@ -255,8 +255,10 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         a = Nani(i);
     end
 
-        % Flux terms
-        F_potential  = epp_norm(i)*dVdx;
+    %% Equation editor
+
+    % F_potential: Flux term for potential
+    F_potential = epp_norm(i)*dVdx;
 
     % F_electron: Flux term for electrons
     % dudx(2) is dndx, gradient of electrons concentration
@@ -265,8 +267,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
     % F_hole: Flux term for holes
     % dudx(3) is dpdx, gradient of holes concentration
     F_hole = mobset*(muh(i)*p*(dVdx - gradIP(i)) + Dp(i)*(dudx(3) - p*gradNv_over_Nv(i)));
-    F = [F_potential; F_electron; F_hole];
-            
+
         % Source terms
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
     % S_electron_hole: Source term for electrons and for holes
@@ -275,21 +276,31 @@ function [C,F,S] = dfpde(x,t,u,dudx)
     S = [S_potential; S_electron_hole; S_electron_hole];
         
     if N_ionic_species % Condition for cation and anion terms
-            
-        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
 
-        F = [F; F_cation];
+        % F_cation: Flux term for cations
+        % dudx(4) is dcdx, gradient of mobile cation concentration
+        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
             
             S_cation = 0;
             S = [S; S_cation];
         if N_ionic_species_two % Condition for anion terms
-            
+
+            % F_anion: Flux term for anions
+            % dudx(5) is dadx, gradient of mobile anion concentration
             F_anion = K_anion*mobseti*muani(i)*(a*-dVdx + kBT*(dadx+(a*(dadx/(DOSani(i)-a)))));
-            F = [F; F_anion];
+
+            % F: Flux terms
+            F = [F_potential; F_electron; F_hole; F_cation; F_anion];
             
             S_anion = 0;
             S = [S; S_anion];
+        else
+            % F: Flux terms
+            F = [F_potential; F_electron; F_hole; F_cation];
         end
+    else
+        % F: Flux terms
+        F = [F_potential; F_electron; F_hole];
     end
 end
 

--- a/Core/df.m
+++ b/Core/df.m
@@ -166,6 +166,9 @@ NANDNaniNcat = -NA+ND+Nani-Ncat;
 % pre-calculate kB*T
 kBT = kB*T;
 
+% pre-calculate the squared values of ni
+ni_squared = ni.^2;
+
 % convert to boolean for faster check in dfode
 g1_fun_type_constant = g1_fun_type == "constant";
 g2_fun_type_constant = g2_fun_type == "constant";
@@ -255,8 +258,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             
         % Source terms
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
-        S_electron = g - radset*B(i)*((n*p)-(ni(i)^2)) - SRHset*(((n*p)-ni(i)^2)/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
-        S_hole     = g - radset*B(i)*((n*p)-(ni(i)^2)) - SRHset*(((n*p)-ni(i)^2)/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
+        S_electron = g - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
+        S_hole     = g - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S = [S_potential; S_electron; S_hole];
         
         if N_ionic_species == 1 || N_ionic_species == 2  % Condition for cation and anion terms

--- a/Core/df.m
+++ b/Core/df.m
@@ -169,6 +169,10 @@ kBT = kB*T;
 % pre-calculate the squared values of ni
 ni_squared = ni.^2;
 
+% pre-calculate
+gradNc_over_Nc = gradNc./Nc;
+gradNv_over_Nv = gradNv./Nv;
+
 % convert to boolean for faster check in dfode
 g1_fun_type_constant = g1_fun_type == "constant";
 g2_fun_type_constant = g2_fun_type == "constant";
@@ -252,8 +256,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         
         % Flux terms
         F_potential  = epp_norm(i)*dVdx;
-        F_electron   = mue(i)*n*(-dVdx + gradEA(i)) + (Dn(i)*(dndx - ((n/Nc(i))*gradNc(i))));
-        F_hole       = muh(i)*p*(dVdx - gradIP(i)) + (Dp(i)*(dpdx - ((p/Nv(i))*gradNv(i))));      
+        F_electron   = mue(i)*n*(-dVdx + gradEA(i)) + Dn(i)*(dndx - n*gradNc_over_Nc(i));
+        F_hole       = muh(i)*p*(dVdx - gradIP(i)) + Dp(i)*(dpdx - p*gradNv_over_Nv(i));
         F = [F_potential; mobset*F_electron; mobset*F_hole]; 
             
         % Source terms

--- a/Core/df.m
+++ b/Core/df.m
@@ -260,12 +260,12 @@ function [C,F,S] = dfpde(x,t,u,dudx)
 
     % F_electron: Flux term for electrons
     % dudx(2) is dndx, gradient of electrons concentration
-    F_electron   = mue(i)*n*(-dVdx + gradEA(i)) + Dn(i)*(dudx(2) - n*gradNc_over_Nc(i));
+    F_electron = mobset*(mue(i)*n*(-dVdx + gradEA(i)) + Dn(i)*(dudx(2) - n*gradNc_over_Nc(i)));
 
     % F_hole: Flux term for holes
     % dudx(3) is dpdx, gradient of holes concentration
-    F_hole       = muh(i)*p*(dVdx - gradIP(i)) + Dp(i)*(dudx(3) - p*gradNv_over_Nv(i));
-        F = [F_potential; mobset*F_electron; mobset*F_hole]; 
+    F_hole = mobset*(muh(i)*p*(dVdx - gradIP(i)) + Dp(i)*(dudx(3) - p*gradNv_over_Nv(i)));
+    F = [F_potential; F_electron; F_hole];
             
         % Source terms
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
@@ -275,16 +275,16 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         
     if N_ionic_species % Condition for cation and anion terms
             
-            F_cation = mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
+        F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
 
-            F = [F; K_cation*mobseti*F_cation];
+        F = [F; F_cation];
             
             S_cation = 0;
             S = [S; S_cation];
         if N_ionic_species_two % Condition for anion terms
             
-            F_anion = muani(i)*(a*-dVdx + kBT*(dadx+(a*(dadx/(DOSani(i)-a)))));
-            F = [F; K_anion*mobseti*F_anion];
+            F_anion = K_anion*mobseti*muani(i)*(a*-dVdx + kBT*(dadx+(a*(dadx/(DOSani(i)-a)))));
+            F = [F; F_anion];
             
             S_anion = 0;
             S = [S; S_anion];

--- a/Core/df.m
+++ b/Core/df.m
@@ -231,9 +231,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
     else
         gxt2 = g2_fun(g2_fun_arg, t)*gx2(i);
     end
-        
-        g = gxt1 + gxt2;
-        
+
         %% Variables
         V = u(1); n = u(2); p = u(3); 
 
@@ -262,8 +260,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             
         % Source terms
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
-        S_electron = g - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
-        S_hole     = g - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
+        S_electron = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
+        S_hole     = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S = [S_potential; S_electron; S_hole];
         
         if N_ionic_species == 1 || N_ionic_species == 2  % Condition for cation and anion terms

--- a/Core/df.m
+++ b/Core/df.m
@@ -272,17 +272,13 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
     % S_electron_hole: Source term for electrons and for holes
     S_electron_hole = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
-
-    S = [S_potential; S_electron_hole; S_electron_hole];
         
     if N_ionic_species % Condition for cation and anion terms
 
         % F_cation: Flux term for cations
         % dudx(4) is dcdx, gradient of mobile cation concentration
         F_cation = K_cation*mobseti*mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
-            
-            S_cation = 0;
-            S = [S; S_cation];
+
         if N_ionic_species_two % Condition for anion terms
 
             % F_anion: Flux term for anions
@@ -292,15 +288,21 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             % F: Flux terms
             F = [F_potential; F_electron; F_hole; F_cation; F_anion];
             
-            S_anion = 0;
-            S = [S; S_anion];
+            % S: Source terms
+            S = [S_potential; S_electron_hole; S_electron_hole; 0; 0];
         else
             % F: Flux terms
             F = [F_potential; F_electron; F_hole; F_cation];
+
+            % S: Source terms
+            S = [S_potential; S_electron_hole; S_electron_hole; 0];
         end
     else
         % F: Flux terms
         F = [F_potential; F_electron; F_hole];
+
+        % S: Source terms
+        S = [S_potential;S_electron_hole;S_electron_hole];
     end
 end
 

--- a/Core/df.m
+++ b/Core/df.m
@@ -235,7 +235,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
     % Variables
     n = u(2); p = u(3);
 
-        if N_ionic_species == 1
+    if N_ionic_species
             c = u(4);           % Include cation variable
             dcdx = dudx(4);
             a = Nani(i);
@@ -264,7 +264,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         S_hole     = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S = [S_potential; S_electron; S_hole];
         
-        if N_ionic_species == 1 || N_ionic_species == 2  % Condition for cation and anion terms
+    if N_ionic_species % Condition for cation and anion terms
             
             F_cation = mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
 

--- a/Core/df.m
+++ b/Core/df.m
@@ -160,6 +160,9 @@ int2gx2 = int2*gx2;
 % S_potential prefactor
 q_over_eppmax_epp0 = q/(eppmax*epp0);
 
+% pre-calculation S_potential static charge
+NANDNaniNcat = -NA+ND+Nani-Ncat;
+
 % convert to boolean for faster check in dfode
 g1_fun_type_constant = g1_fun_type == "constant";
 g2_fun_type_constant = g2_fun_type == "constant";
@@ -248,7 +251,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         F = [F_potential; mobset*F_electron; mobset*F_hole]; 
             
         % Source terms
-        S_potential = q_over_eppmax_epp0*(-n+p-NA(i)+ND(i)-a+c+Nani(i)-Ncat(i));
+        S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
         S_electron = g - radset*B(i)*((n*p)-(ni(i)^2)) - SRHset*(((n*p)-ni(i)^2)/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S_hole     = g - radset*B(i)*((n*p)-(ni(i)^2)) - SRHset*(((n*p)-ni(i)^2)/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S = [S_potential; S_electron; S_hole];

--- a/Core/df.m
+++ b/Core/df.m
@@ -163,6 +163,9 @@ q_over_eppmax_epp0 = q/(eppmax*epp0);
 % pre-calculation S_potential static charge
 NANDNaniNcat = -NA+ND+Nani-Ncat;
 
+% pre-calculate kB*T
+kBT = kB*T;
+
 % convert to boolean for faster check in dfode
 g1_fun_type_constant = g1_fun_type == "constant";
 g2_fun_type_constant = g2_fun_type == "constant";
@@ -258,7 +261,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         
         if N_ionic_species == 1 || N_ionic_species == 2  % Condition for cation and anion terms
             
-            F_cation = mucat(i)*(c*dVdx + kB*T*(dcdx + (c*(dcdx/(DOScat(i)-c))))); 
+            F_cation = mucat(i)*(c*dVdx + kBT*(dcdx + (c*(dcdx/(DOScat(i)-c)))));
+
             F = [F; K_cation*mobseti*F_cation];
             
             S_cation = 0;
@@ -267,7 +271,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         
         if N_ionic_species == 2     % Condition for anion terms
             
-            F_anion = muani(i)*(a*-dVdx + kB*T*(dadx+(a*(dadx/(DOSani(i)-a)))));
+            F_anion = muani(i)*(a*-dVdx + kBT*(dadx+(a*(dadx/(DOSani(i)-a)))));
             F = [F; K_anion*mobseti*F_anion];
             
             S_anion = 0;

--- a/Core/df.m
+++ b/Core/df.m
@@ -150,6 +150,10 @@ x_ihalf_padded = [x_ihalf, nan(1,sampling_step-mod(x_ihalf_length,sampling_step)
 x_ihalf_padded_mat = reshape(x_ihalf_padded,sampling_step,[]);
 x_ihalf_sampled = x_ihalf_padded_mat(1,:);
 
+% prepare constant generation profiles
+int1gx1 = int1*gx1;
+int2gx2 = int2*gx2;
+
 % convert to boolean for faster check in dfode
 g1_fun_type_constant = g1_fun_type == "constant";
 g2_fun_type_constant = g2_fun_type == "constant";
@@ -198,13 +202,13 @@ function [C,F,S] = dfpde(x,t,u,dudx)
 
     % g: Generation terms
     if g1_fun_type_constant
-        gxt1 = int1*gx1(i);
+        gxt1 = int1gx1(i);
     else
         gxt1 = g1_fun(g1_fun_arg, t)*gx1(i);
     end
 
     if g2_fun_type_constant
-        gxt2 = int2*gx2(i);
+        gxt2 = int2gx2(i);
     else
         gxt2 = g2_fun(g2_fun_arg, t)*gx2(i);
     end

--- a/Core/df.m
+++ b/Core/df.m
@@ -185,6 +185,7 @@ switch N_ionic_species
         C_hole = 1;
         C_cation = 1;
         Cpre = [C_potential; C_electron; C_hole; C_cation];
+        N_ionic_species_two = false;
     case 2
         C_potential = 0;
         C_electron = 1;
@@ -192,11 +193,13 @@ switch N_ionic_species
         C_cation = 1;
         C_anion = 1;
         Cpre = [C_potential; C_electron; C_hole; C_cation; C_anion];
+        N_ionic_species_two = true;
     otherwise
         C_potential = 0;
         C_electron = 1;
         C_hole = 1;
         Cpre = [C_potential; C_electron; C_hole];
+        N_ionic_species_two = false;
 end
 
 %% Call solver
@@ -239,15 +242,16 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             c = u(4);           % Include cation variable
             dcdx = dudx(4);
             a = Nani(i);
-        elseif N_ionic_species == 2
+        if N_ionic_species_two
             c = u(4);           % Include cation variable
             a = u(5);           % Include anion variable
             dcdx = dudx(4);
-            dadx = dudx(5);    
-        else
-            c = Ncat(i);
-            a = Nani(i);
+            dadx = dudx(5);
         end
+    else
+        c = Ncat(i);
+        a = Nani(i);
+    end
         
         %% Gradients
         dVdx = dudx(1); dndx = dudx(2); dpdx = dudx(3); 
@@ -272,9 +276,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             
             S_cation = 0;
             S = [S; S_cation];
-        end
-        
-        if N_ionic_species == 2     % Condition for anion terms
+        if N_ionic_species_two % Condition for anion terms
             
             F_anion = muani(i)*(a*-dVdx + kBT*(dadx+(a*(dadx/(DOSani(i)-a)))));
             F = [F; K_anion*mobseti*F_anion];
@@ -282,8 +284,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             S_anion = 0;
             S = [S; S_anion];
         end
-        
     end
+end
 
 %% Define initial conditions.
     function u0 = dfic(x)

--- a/Core/df.m
+++ b/Core/df.m
@@ -269,9 +269,10 @@ function [C,F,S] = dfpde(x,t,u,dudx)
             
         % Source terms
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
-        S_electron = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
-        S_hole     = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
-        S = [S_potential; S_electron; S_hole];
+    % S_electron_hole: Source term for electrons and for holes
+    S_electron_hole = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
+
+    S = [S_potential; S_electron_hole; S_electron_hole];
         
     if N_ionic_species % Condition for cation and anion terms
             

--- a/Core/df.m
+++ b/Core/df.m
@@ -157,6 +157,9 @@ epp_norm = epp/eppmax;
 int1gx1 = int1*gx1;
 int2gx2 = int2*gx2;
 
+% S_potential prefactor
+q_over_eppmax_epp0 = q/(eppmax*epp0);
+
 % convert to boolean for faster check in dfode
 g1_fun_type_constant = g1_fun_type == "constant";
 g2_fun_type_constant = g2_fun_type == "constant";
@@ -245,7 +248,7 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         F = [F_potential; mobset*F_electron; mobset*F_hole]; 
             
         % Source terms
-        S_potential = (q/(eppmax*epp0))*(-n+p-NA(i)+ND(i)-a+c+Nani(i)-Ncat(i));
+        S_potential = q_over_eppmax_epp0*(-n+p-NA(i)+ND(i)-a+c+Nani(i)-Ncat(i));
         S_electron = g - radset*B(i)*((n*p)-(ni(i)^2)) - SRHset*(((n*p)-ni(i)^2)/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S_hole     = g - radset*B(i)*((n*p)-(ni(i)^2)) - SRHset*(((n*p)-ni(i)^2)/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
         S = [S_potential; S_electron; S_hole];

--- a/Core/df.m
+++ b/Core/df.m
@@ -232,8 +232,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         gxt2 = g2_fun(g2_fun_arg, t)*gx2(i);
     end
 
-        %% Variables
-        V = u(1); n = u(2); p = u(3); 
+    % Variables
+    n = u(2); p = u(3);
 
         if N_ionic_species == 1
             c = u(4);           % Include cation variable

--- a/Core/df.m
+++ b/Core/df.m
@@ -268,8 +268,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         % Source terms
         S_potential = q_over_eppmax_epp0*(-n+p-a+c+NANDNaniNcat(i));
     % S_electron_hole: Source term for electrons and for holes
-    S_electron_hole = gxt1 + gxt2 - radset*B(i)*((n*p)-(ni_squared(i))) - SRHset*(((n*p)-ni_squared(i))/((taun(i)*(p+pt(i)))+(taup(i)*(n+nt(i)))));
-        
+    S_electron_hole = gxt1 + gxt2 - radset*B(i)*(n*p-ni_squared(i)) - SRHset*(n*p-ni_squared(i))/(taun(i)*(p+pt(i)) + taup(i)*(n+nt(i)));
+
     if N_ionic_species % Condition for cation and anion terms
 
         % F_cation: Flux term for cations

--- a/Core/df.m
+++ b/Core/df.m
@@ -237,6 +237,8 @@ function [C,F,S] = dfpde(x,t,u,dudx)
 
     % Variables
     n = u(2); p = u(3);
+    % gradient of electrostatic potential, electric field
+    dVdx = dudx(1);
 
     if N_ionic_species
             c = u(4);           % Include cation variable
@@ -252,14 +254,17 @@ function [C,F,S] = dfpde(x,t,u,dudx)
         c = Ncat(i);
         a = Nani(i);
     end
-        
-        %% Gradients
-        dVdx = dudx(1); dndx = dudx(2); dpdx = dudx(3); 
-        
+
         % Flux terms
         F_potential  = epp_norm(i)*dVdx;
-        F_electron   = mue(i)*n*(-dVdx + gradEA(i)) + Dn(i)*(dndx - n*gradNc_over_Nc(i));
-        F_hole       = muh(i)*p*(dVdx - gradIP(i)) + Dp(i)*(dpdx - p*gradNv_over_Nv(i));
+
+    % F_electron: Flux term for electrons
+    % dudx(2) is dndx, gradient of electrons concentration
+    F_electron   = mue(i)*n*(-dVdx + gradEA(i)) + Dn(i)*(dudx(2) - n*gradNc_over_Nc(i));
+
+    % F_hole: Flux term for holes
+    % dudx(3) is dpdx, gradient of holes concentration
+    F_hole       = muh(i)*p*(dVdx - gradIP(i)) + Dp(i)*(dudx(3) - p*gradNv_over_Nv(i));
         F = [F_potential; mobset*F_electron; mobset*F_hole]; 
             
         % Source terms


### PR DESCRIPTION
The `df.dfpde` function runs millions of times in each simulation (e.g. for running the example in the readme, including `equilibrate` and `doJV`, it runs 3.3 million times).
Currently it accounts for half of the total simulation time.
These changes tries to increase its efficiency without making the code too much ugly.
Even faster code could be obtained moving all the `if` checks outside of the `df.dfpde` function and writing various versions of it including 0, 1 or 2 ions. But this would mean much uglier code.
In the current set of changes the less nice part is the repetition of the `S_potential` expression.
And the slowest part of the function are the two `find` lines, I tried various alternatives (like ismembc2 and builtin _ismemberhelper) with no luck.
I am not super sure that all and each of the commits improve the speed, but must do.

Before the changes, the run time of the `equilibrate` example from the readme was 25.3 s (on my laptop) and after the changes is 17.9 s (further decreases to 17.7 s after applying also #38; further decreases to 13.8 s modifying pdepe for passing over the positional index, see [this question](https://uk.mathworks.com/matlabcentral/answers/518716-how-to-get-positional-index-from-pdepe-into-pde)).
Before the changes, the run time of the `doJV` example from the readme was 31.2 s and after the changes is 19.4 s (further decreases to 18.0 s after applying also #38; further decreases to 14.5 s modifying pdepe for passing over the positional index, see [this question](https://uk.mathworks.com/matlabcentral/answers/518716-how-to-get-positional-index-from-pdepe-into-pde)).
Using Matlab's profile function over the equilibrate and the doJV commands, the execution time of df.dfpde gets reduced to the half.