### PR TITLE
fun_gen remove sweep2

### DIFF
--- a/Core/fun_gen.m
+++ b/Core/fun_gen.m
@@ -34,9 +34,6 @@ switch fun_type
         fun = @(coeff, t) coeff(1) + (coeff(2)-coeff(1))*lt(mod(t,coeff(3))*1/coeff(3),coeff(4)/100);
     case 'sin'
         fun = @(coeff, t) coeff(1) + coeff(2)*(sin(2*pi*coeff(3)*t + coeff(4)));
-    case 'sweep2'
-        fun = @(coeff, t) coeff(1) + [(coeff(2)-coeff(1))*t(t<=coeff(3)/2)/coeff(3),...
-                                   -(coeff(2)-coeff(1))*(t(t>coeff(3)/2)/coeff(3) -  2*t(t==coeff(3)/2)/coeff(3))];
     case 'tri'
         % COEFF = [OFFSET, V1, V2, periods, tperiod]  tmax is defined by the input
         fun = @(coeff, t) triangle_fun(coeff, t);


### PR DESCRIPTION
I don't know why but the sweep2 function is always failing for me with the following error:

```
>> VappFunction(soleq.ion, 'sweep2', [0, 0.1, 1], 1, 30, false);

Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.

Error in pdepe/pdeodes (line 367)
    up(:,nx) = pR;

Error in ode15s (line 579)
        rhs = hinvGak*feval(odeFcn,tnew,ynew,odeArgs{:}) -  Mtnew*(psi+difkp1);

Error in pdepe (line 289)
    [t,y] = ode15s(@pdeodes,t,y0(:),opts);

Error in df (line 213)
u = pdepe(par.m,@dfpde,@dfic,@dfbc,x,t,options);

Error in VappFunction (line 36)
sol = df(sol_ini, par);
```

It works when the tmax closes the simulation before the peak of the sweep2 applied voltage profile.
Could anyone provide a working example? Otherwise I suggest to remove it.