### PR TITLE
explore.plotPL small fixes

### DIFF
--- a/Helper/explore.m
+++ b/Helper/explore.m
@@ -217,10 +217,10 @@ classdef explore
         
         function plotPL(exsol)
             figure(100)
-            s1 = surf(exsol.parval1, exsol.parval2, exsol.stats.PLint);
+            surf(exsol.parval1, exsol.parval2, exsol.stats.PLint(:,:,end));
             ylabel(exsol.parnames(1))
             xlabel(exsol.parnames(2))
-            set(s1,'YScale','log');
+            set(gca,'YScale','log');
             zlabel('PL intensity [cm-2s-1]')
             shading interp
             colorbar


### PR DESCRIPTION
Just the last time point of the Z argument to the surf function should be plotted, otherwise surf will throw an error.
YScale is a property of the axes, it does not exist in the surface object.
