### PR TITLE
genVappStructs preserve par.mobseti if mobseti option is false

### DIFF
--- a/Protocols/genVappStructs.m
+++ b/Protocols/genVappStructs.m
@@ -81,8 +81,6 @@ for i = 1:length(Vapp_arr)-1
         sol.par.K_anion = 1;
         sol.par.K_cation = 1;
         sol.par.mobseti = 1;
-    else
-        sol.par.mobseti = 1;
     end
     % if there's only one solution then duplicate sol structure
     if length(Vapp_arr)-1 == 1


### PR DESCRIPTION
In f9d1841b43c7038afb7d8d489b27cd2e3e53bfab a `mobseti` argument has been implemented in `genVappStructs`.
Both if the input solution had `par.mobseti` set to `false` or `true`, the output solutions have `par.mobseti` set to `true`.
If the `mobseti` argument is `true`, it will set to true also `par.mobseti` but, with this PR, if `mobseti` argument is `false` it will not change `par.mobseti` (which can remain `false` for only electronic mobile charges or `true` for solutions with also ionic mobile charges).