### PR TITLE
dfana change sign in continuity equation

### DIFF
--- a/Core/dfana.m
+++ b/Core/dfana.m
@@ -228,10 +228,10 @@ classdef dfana
             % Recombination
             r = dfana.calcr_ihalf(sol);
 
-            djndx = dndt + g - r.tot;    % Not certain about the sign here
-            djpdx = dpdt + g - r.tot;
-            djadx = dadt;
-            djcdx = dcdt;
+            djndx = - dndt + g - r.tot;
+            djpdx = - dpdt + g - r.tot;
+            djadx = - dadt;
+            djcdx = - dcdt;
             
             switch option
                 case 0


### PR DESCRIPTION
Simulating impedance spectroscopy I saw weird currents and I suspect that this is due to an error in the continuity equations used for calculating the currents in `Core/dfana.calcJ`.

This error seems to have been originated in f8da9381a09696a24617b6593ded6dafe60f5160.

Please check, I could be wrong!