### PR TITLE
stabilize: limit to 10 iterations

### DIFF
--- a/Protocols/stabilize.m
+++ b/Protocols/stabilize.m
@@ -90,7 +90,14 @@ end
 % the warnings are not needed here
 warning('off', 'df:verifyStabilization');
 
+i=0;
 while forceStabilization || ~verifyStabilization(steadystate_struct.u, steadystate_struct.t, 1e-3) % check stability
+    i = i + 1;
+    if i > 10
+        warning('Driftfusion:stabilize', [mfilename ' - not stabile after 10 attempts, giving up.']);
+        break
+    end
+
     disp([mfilename ' - Stabilizing ' inputname(1) ' over ' num2str(par.tmax) ' s with an applied voltage of ' num2str(par.Vapp) ' V']);
     % every cycle starts from the last timepoint of the previous cycle
     steadystate_struct = df(steadystate_struct, par);


### PR DESCRIPTION
In some cases, for example when the equilibration routine breaks before the last time point, the stabilization never succeeds and enters in an infinite loop. This PR limits the attempts to 10.