### PR TITLE
equilibrate fix initial concentration of cations

### DIFF
--- a/Protocols/equilibrate.m
+++ b/Protocols/equilibrate.m
@@ -126,9 +126,9 @@ if electronic_only == 0
     % Write ionic initial conditions
     switch par.N_ionic_species
         case 1
-            sol.u(:,:,4) = repmat(par.dev.Nani, length(sol.t), 1);
+            sol.u(:,:,4) = repmat(par.dev.Ncat, length(sol.t), 1);
         case 2
-            sol.u(:,:,4) = repmat(par.dev.Nani, length(sol.t), 1);
+            sol.u(:,:,4) = repmat(par.dev.Ncat, length(sol.t), 1);
             sol.u(:,:,5) = repmat(par.dev.Nani, length(sol.t), 1);
     end
     


### PR DESCRIPTION
Currently the concentration of cations is set based on Nani instead of Ncat.
This PR fixes.