### PR TITLE
findVoc unset K_anion and K_cation

### DIFF
--- a/Protocols/findVoc.m
+++ b/Protocols/findVoc.m
@@ -169,6 +169,8 @@ while abs(fx1) > tol
 end
 
 sol_Voc = sol;
+sol_Voc.par.K_anion = 1;
+sol_Voc.par.K_cation = 1;
 
 Voc = x1;
 


### PR DESCRIPTION
When using `Protocols/findVoc.m` with `mobseti` argument set to true, the variables `par.K_anion` and `par.K_cation` get set.
The problem is that they are not reset to `1` before the solution is returned.
This causes very weird results when using the output of `findVoc`, as the ions are accelerated.