### PR TITLE
Add Protocols/genIntStructsVoc.m and Protocols/findVocOptim.m

### DIFF
--- a/Core/fun_gen.m
+++ b/Core/fun_gen.m
@@ -14,6 +14,8 @@ function fun = fun_gen(fun_type)
 % COEFF = [A_low, A_high, time_period, duty_cycle]
 %% 'sin'
 % COEFF = [DC_offset, Delta_AC, frequency, phase]
+%% 'sweepAndStill'
+% COEFF = [A_start, A_end, sweep_duration]
 %
 %% LICENSE
 % Copyright (C) 2020  Philip Calado, Ilario Gelmetti, and Piers R. F. Barnes
@@ -40,4 +42,9 @@ switch fun_type
     case 'tri'
         % COEFF = [OFFSET, V1, V2, periods, tperiod]  tmax is defined by the input
         fun = @(coeff, t) triangle_fun(coeff, t);
+    case 'sweepAndStill'
+        % COEFF = [A_start, A_end, sweep_duration]
+        % do a sweep from coeff(1) to coeff(2) with the duration of
+        % coeff(3), then stay stable at coeff(2)
+        fun = @(coeff, t) coeff(2) + (coeff(1)-coeff(2))*max(0,1-t/coeff(3));
 end

--- a/Protocols/findVocOptim.m
+++ b/Protocols/findVocOptim.m
@@ -1,0 +1,183 @@
+function [struct_voc, Voc] = findVocOptim(struct, approxVoc)
+%FINDVOCOPTIM - Stabilize a solution to the real open circuit voltage using MATLAB's Optimization Toolbox
+% The Voc found is the applied voltage where the current is minimized,
+% starting from the voltage present in the given solution. 
+% Requires MATLAB's Optimization Toolbox.
+%
+% Syntax:  [struct_voc, Voc] = findVocOptim(struct)
+%
+% Inputs:
+%   STRUCT - a struct as created by DF
+%   APPROXVOC - optional numeric, an initial guess for the Voc voltage, if
+%     it is missing, the search will take more time
+%
+% Outputs:
+%   STRUCT_VOC - a struct as created by DF with applied voltage identical
+%     to the real open circuit voltage
+%   VOC - the value of the obtained open circuit voltage
+%
+% Example:
+%   [soleq_ion_voc, Voc] = findVocOptim(soleq.ion)
+%     get closer to the real VOC and save the open circuit voltage value in Voc variable
+%
+% Other m-files required: df, dfana, stabilize
+% Subfunctions: IgiveCurrentForVoltage
+% MAT-files required: none
+%
+% See also df, findVoc, findVocDirect, dfana.
+
+% Author: Ilario Gelmetti, Ph.D. student, perovskite photovoltaics
+% Institute of Chemical Research of Catalonia (ICIQ)
+% Research Group Prof. Emilio Palomares
+% email address: iochesonome@gmail.com
+% Supervised by: Dr. Phil Calado, Dr. Piers Barnes, Prof. Jenny Nelson
+% Imperial College London
+% April 2018; Last revision: June 2020
+
+%------------- BEGIN CODE --------------
+
+
+% set an initial time for stabilization tmax
+if any(struct.par.mucat) && struct.par.mobseti
+    struct.par.tmax = min(5e0, 2^(-log10(max(struct.par.mucat))) / 10 + 2^(-log10(min(struct.par.mue))));
+else
+    struct.par.tmax = min(1e-2, 2^(-log10(min(struct.par.mue))));
+end
+
+struct.par.tpoints = 10;
+struct.par.t0 = struct.par.tmax / 1e6;
+
+% if an approximated Voc is provided, start from that
+if nargin > 1 && struct.par.Vapp ~= approxVoc
+    struct.par.V_fun_arg = [struct.par.Vapp, approxVoc, 10 * struct.par.t0];
+    % starts at Vstart, linear Vapp decrease for the first points, then constant to Vend
+    struct.par.V_fun_type = 'sweepAndStill';
+    struct = df(struct, struct.par);
+    
+    struct.par.V_fun_type = 'constant';
+    struct.par.V_fun_arg = approxVoc;
+    struct = stabilize(struct); % go to steady state
+end
+
+% find residual current
+originalCurrent = dfana.calcJ(struct);
+
+disp([mfilename ' - Original voltage: ' num2str(struct.par.Vapp, 8) ' V; original current: ' num2str(originalCurrent.tot(end,end)) ' A/cm2'])
+
+%% estimate search range, assuming that a higher voltage causes a more positive current
+
+% preallocate with the value from input solution
+previousCurrent = originalCurrent.tot(end,end);
+% set a fallback value in case the for cycle doesn't find a good one
+dVlimit = 1.4;
+% look for the residual current at a new voltage,
+% if the sign of the residual current is different use the voltage
+% variation as a search range limit
+for dV = [0.001, 0.01, 0.05, repelem(0.2, 4), repelem(0.05, 9)]
+    % this assumes that a more positive voltage results in more positive
+    % current
+    [~, newCurrent, struct_newVapp] = IgiveCurrentForVoltage(struct, struct.par.Vapp - sign(previousCurrent) * dV);
+    if sign(newCurrent) ~= sign(originalCurrent.tot(end,end))
+        dVlimit = dV;
+        % if the current is smaller, the new solution is used as starting
+        % point, otherwise the solution of the previous cycle is used
+        if abs(newCurrent) < abs(previousCurrent)
+            struct = struct_newVapp;
+        end
+        break
+    else
+        % the new solution is used as next point
+        struct = struct_newVapp;
+        % store the new solution current value for next cycle
+        previousCurrent = newCurrent;
+    end
+end
+
+disp([mfilename ' - Search range: ' num2str(dVlimit) ' V'])
+
+%% do the search
+
+% the tmax obtained in the previous step could be too big and make some next step to fail
+struct.par.tmax = struct.par.tmax / 10;
+struct.par.t0 = struct.par.t0 / 10;
+
+% here struct is a fixed input, while Vapp is the input that will be
+% optimized
+fun = @(Vapp) IgiveCurrentForVoltage(struct, Vapp);
+
+% StepTolerance is usually what stops the minimization here
+% MaxFunctionEvaluations is 100 by default, reducing to 30 but even smaller
+% values could be enough
+options = optimoptions(@fmincon, 'StepTolerance', 1e-7, 'FunctionTolerance', 1e-11, 'OptimalityTolerance', 1e-11, 'Algorithm', 'active-set', 'Display', 'notify', 'MaxFunctionEvaluations', 30);
+
+% the starting point is the currently present voltage
+% the constraints does not work when using the default interior-point
+% algorithm, no idea why
+Voc = fmincon(fun, struct.par.Vapp, [1; -1], [struct.par.Vapp + dVlimit; -(struct.par.Vapp - dVlimit)], [], [], [], [], [], options);
+
+%% stabilize at the real Voc
+
+struct.par.tpoints = 20;
+
+struct.par.V_fun_arg = [struct.par.Vapp, Voc, 10 * struct.par.t0];
+% starts at Vstart, linear Vapp decrease for the first points, then constant to Vend
+struct.par.V_fun_type = 'sweepAndStill';
+
+struct_voc = df(struct, struct.par);
+
+%% stabilize
+
+struct_voc.par.V_fun_type = 'constant';
+struct_voc.par.V_fun_arg = Voc;
+
+struct_voc = stabilize(struct_voc); % go to steady state
+
+residualJ = dfana.calcJ(struct_voc);
+
+disp([mfilename ' - VOC found at ' num2str(Voc, 10) ' V, residual current ' num2str(residualJ.tot(end,end)) ' A/cm2'])
+
+end
+
+%% take out the last current point
+function [minimizeMe, current, struct_newVapp] = IgiveCurrentForVoltage(struct, Vapp)
+
+par = struct.par;
+
+Vstart = par.Vapp; % current applied voltage
+Vend = Vapp; % new Voc    
+% the third parameter is the time point when the change from the old
+% voltage to the new one happens
+par.V_fun_arg = [Vstart, Vend, 10 * par.t0];
+% starts at Vstart, linear Vapp decrease for the first points, then constant to Vend
+par.V_fun_type = 'sweepAndStill';
+
+% the voltage step simulation can fail, shortening tmax (as in the catch block) could solve
+try
+    struct_newVapp = df(struct, par);
+catch
+    disp([mfilename ' - the voltage change failed, trying again with shorter tmax'])
+    par.tmax = par.tmax / 10;
+    par.t0 = par.t0 / 10;
+    struct_newVapp = df(struct, par);
+end
+
+struct_newVapp.par.V_fun_type = 'constant';
+struct_newVapp.par.V_fun_arg = Vend;
+
+struct_newVapp = stabilize(struct_newVapp);
+
+J = dfana.calcJ(struct_newVapp);
+
+current = J.tot(end,end);
+% I want the absolute value, but it's nicer to take the squared rather than
+% the abs, for not introducing non derivable points
+% the stupid multiplicative factor is needed for getting far from the eps
+% (double precision) which is the minimum FunctionTolerance which can be
+% set
+minimizeMe = 1e30 * current^2;
+
+disp([mfilename ' - Using with Vapp ' num2str(struct_newVapp.par.Vapp, 8) ' V, a current of ' num2str(current) ' A/cm2 was found'])
+
+end
+
+%------------- END OF CODE --------------

--- a/Protocols/genIntStructsVoc.m
+++ b/Protocols/genIntStructsVoc.m
@@ -1,0 +1,96 @@
+function [structs_oc, VOCs] = genIntStructsVoc(struct_eq, startInt, endInt, points, include_dark)
+% GENINTSTRUCTSVOC - Generates a cell containing structures of solutions at various light intensities at an accurate VOC
+% This script just uses other two scripts: genIntStructs, findVocOptim.
+%
+% Syntax:  [structs_oc, VOCs] = genIntStructsVoc(struct_eq, startInt, endInt, points, include_dark)
+%
+% Inputs:
+%   STRUCT_EQ - a solution struct as created by DRIFTFUSION in dark
+%     conditions, preferably a symmetric (open circuit) solution
+%   STARTINT - higher requested illumination.
+%   ENDINT - lower requested illumination.
+%   POINTS - number of illumination requested between STARTINT and ENDINT, including extrema, except dark.
+%   INCLUDE_DARK - logical, if to include the dark solution in the output
+%     structure
+%
+% Outputs:
+%   STRUCTS_OC - a cell containing structs of asymmetric solutions at various light
+%     intensities with an applied voltage equal to the VOC
+%   VOCS - an array with the calculated VOC
+%
+% Example:
+%   [structs_oc, VOCs] = genIntStructsVoc(soleq.ion, 10, 1e-3, 5, true)
+%     prepare solutions at 10, 1, 0.1, 0.01, 0.001 and 0 illumination intensities
+%
+% Other m-files required: df, genIntStructs, findVocOptim
+% Subfunctions: none
+% MAT-files required: none
+%
+% See also genVappStructs, changeLight, df, genIntStructs, findVocOptim.
+%
+%% LICENSE
+% Copyright (C) 2020  Philip Calado, Ilario Gelmetti, and Piers R. F. Barnes
+% Imperial College London
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU Affero General Public License as published
+% by the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% Ilario Gelmetti, Ph.D. student, perovskite photovoltaics
+% Institute of Chemical Research of Catalonia (ICIQ)
+% Research Group Prof. Emilio Palomares
+% email address: iochesonome@gmail.com
+% Supervised by: Dr. Phil Calado, Dr. Piers Barnes, Prof. Jenny Nelson
+% Imperial College London
+% May 2018; Last revision: May 2018
+
+%------------- BEGIN CODE --------------
+
+% use the normal genIntStructs for obtaining a cell with structs at various
+% light intensities
+[structs_sc, ~, ~] = genIntStructs(struct_eq, startInt, endInt, points, include_dark);
+
+% how many solutions have been obtained
+nsolutions = length(structs_sc(1,:));
+
+% preallocate
+VOCs = NaN(1, nsolutions);
+% the second row of this cell, containing the solutions names, will not be
+% changed
+structs_oc = structs_sc;
+
+%% generate solutions
+for i = 1:nsolutions
+    
+    % decrease annoiance by figures popping up
+    %SCStructCell{1, i}.par.figson = 0;
+    
+    struct_Int = structs_sc{1, i};
+    % the asymmetricized solution could require some stabilization after
+    % breaking
+    %struct_Int = stabilize(struct_Int);
+    
+    % use findVocOptim for finding the applied voltage that minimizes the
+    % residual current
+    disp([mfilename ' - finding real Voc for illumination intensity ' num2str(structs_sc{1, i}.par.int1)])
+
+    % if solution seems at short circuit, estimate a voltage based on int1
+    % illumination
+    if abs(struct_Int.par.Vapp) < 0.1
+        % findVocDirect could be used but it's slow
+        %[~, guessVoc] = findVocDirect(struct_Int, struct_Int.par.int1, 1);
+
+        % very rough estimation of guessVoc
+        guessVoc = 1 + 0.035 * log(struct_Int.par.int1 - 0.0002);
+        [struct_Int_Voc, VOC] = findVocOptim(struct_Int, guessVoc);
+    else
+        [struct_Int_Voc, VOC] = findVocOptim(struct_Int);
+    end
+
+    % replace the solution at the bad VOC with the new one
+    structs_oc{1, i} = struct_Int_Voc;
+    % populate the array containing VOCs
+    VOCs(i) = VOC;
+end
+
+%------------- END OF CODE --------------


### PR DESCRIPTION
`Protocols/findVocOptim.m` is very similar to `Protocols/findVoc.m` (but not to `Protocols/findVocDirect.m` which adds a series resistance to the solution): it takes a solution in input (and optionally also a suggested voltage) and returns the solution at the open circuit voltage, and the relative voltage value.
The main difference from findVoc is that it uses Matlab's Optimization Toolbox for searching for the minimum.

Internally it uses a new voltage function that this PR adds to `Core/fun_gen.m` which is `sweepAndStill`: at first it does a sweep and after this it stays fixed to the final sweep value.

Similarly to `genIntStructs`, `Protocols/genIntStructsVoc.m` generates a cell containing the solutions at various illuminations but with an applied voltage equal to the respective open circuit voltage. It uses `findVocOptim` for finding the Voc value.