### PR TITLE
MaxStep should not depend on t0

### DIFF
--- a/Core/df.m
+++ b/Core/df.m
@@ -149,7 +149,7 @@ J = 0;
 
 %% Solver options
 % MaxStep = limit maximum time step size during integration
-options = odeset('MaxStep', par.MaxStepFactor*0.1*abs(par.tmax - par.t0), 'RelTol', par.RelTol, 'AbsTol', par.AbsTol, 'NonNegative', [1,1,1,0]);
+options = odeset('MaxStep', par.MaxStepFactor*0.1*par.tmax, 'RelTol', par.RelTol, 'AbsTol', par.AbsTol, 'NonNegative', [1,1,1,0]);
 
 %% Call solver
 % inputs with '@' are function handles to the subfunctions


### PR DESCRIPTION
For calculating the `MaxStep` solver option in `df`, the parameter `t0` is also employed:
https://github.com/barnesgroupICL/Driftfusion/blob/8090c3c0198f4efaa3637a83101fc6e336d6ef5d/Core/df.m#L151-L152

This comes from the MaxStep default value.
But when using a linear time mesh (`tmesh_type=1`) the `t0` is not used and should not have any impact on the solution.