### PR TITLE
Built properties

### DIFF
--- a/Core/build_property.m
+++ b/Core/build_property.m
@@ -74,14 +74,16 @@ for i=1:length(par.dcum)                % i is the layer index
                             end
                         case 'surface_rec_taun'
                                 devprop(j) = (deff/par.sn(i))*exp(-abs(alpha)*xprime_n);
+                                % devprop(j) = 1/par.sn(i));
                         case 'surface_rec_taup'
                                 devprop(j) = (deff/par.sp(i))*exp(-abs(beta)*xprime_p);
+                                % devprop(j) = 1/par.sp(i));
                         case 'surface_rec_nt'
-                                devprop(j) = par.nt(i)*exp(-abs(alpha)*xprime_n);
+                                devprop(j) = par.nt(i-1)*exp(-abs(alpha)*xprime_n);
                         case 'surface_rec_pt'
-                                devprop(j) = par.pt(i)*exp(-abs(beta)*xprime_p);
+                                devprop(j) = par.pt(i-1)*exp(-abs(beta)*xprime_p);
                         case 'surface_rec_ni_srh'
-                                devprop(j) = par.ni(i)./abs((exp(abs(alpha)*xprime_n).*exp(abs(beta)*xprime_p)).^0.5); 
+                                devprop(j) = par.ni(i-1)./abs((exp(abs(alpha)*xprime_n).*exp(abs(beta)*xprime_p)).^0.5); 
                         case 'mue_interface'
                             if alpha < 0
                                   devprop(j) = par.mue(i-1)*exp(abs(alpha)*xprime_n);

--- a/Scripts/Check_build_device_properties.m
+++ b/Scripts/Check_build_device_properties.m
@@ -1,0 +1,58 @@
+% File to plot the array of parameters builted in  build_device.m
+% run the code before to the end of build_device.m
+
+% Constant properties
+figure; plot(xmesh*1e7,dev.mucat); ylabel('mucat [cm^2/Vs]'); xlabel('x [nm]');
+figure; plot(xmesh*1e7,dev.muani); ylabel('muani [cm^2/Vs]'); xlabel('x [nm]');
+figure; plot(xmesh*1e7,dev.epp); ylabel('epp '); xlabel('x [nm]');
+figure; plot(xmesh*1e7,dev.NTSD); ylabel('NTSD [cm^{-3}]'); xlabel('x [nm]');
+figure; plot(xmesh*1e7,dev.NTSA); ylabel('NTSA [cm^{-3}]'); xlabel('x [nm]');
+ 
+% Linearly graded properties
+figure; plot(xmesh*1e7,dev.EA,'b',xmesh*1e7,dev.IP,'r',xmesh*1e7,dev.E0,'k');
+ylabel('EA, IP, E0 [eV]'); xlabel('x [nm]'); legend('EA','IP','E0');
+
+% Linearly graded properties
+figure; plot(xmesh*1e7,dev.NA,'b',xmesh*1e7,dev.IP,'r',xmesh*1e7,dev.E0,'k');
+ylabel('EA, IP, E0 [eV]'); xlabel('x [nm]'); legend('EA','IP','E0');
+
+% Logarithmically graded properties
+figure; plot(xmesh*1e7,dev.Nc,'r-',xmesh*1e7,dev.Nv,'b-'); 
+ylabel('Nc, Nv [cm^{-3}]'); xlabel('x [nm]');legend('Nc','Nv');
+figure; plot(xmesh*1e7,dev.n0,'r-',xmesh*1e7,dev.p0,'b-'); 
+ylabel('n0, p0 [cm^{-3}]'); xlabel('x [nm]');legend('n0','p0');
+figure; plot(xmesh*1e7,dev.Nani,'r-',xmesh*1e7,dev.Ncat,'b-'); 
+ylabel('Nani, Ncat [cm^{-3}]'); xlabel('x [nm]');legend('Nani','Ncat');
+figure; plot(xmesh*1e7,dev.ni); ylabel('ni (log_graded) [cm^{-3}]'); xlabel('x [nm]');
+figure; plot(xmesh*1e7,dev.DOSani,'r-',xmesh*1e7,dev.DOScat,'b-'); 
+ylabel('par.amax (DOSani), par.cmax (log_graded) [cm^{-3}]'); xlabel('x [nm]');legend('Nc','Nv');
+
+% Properties that are zeroed in the interfaces
+figure; plot(xmesh*1e7,dev.NA,'r-',xmesh*1e7,dev.NA,'b-'); 
+ylabel('NA, ND [cm^{-3}]'); xlabel('x [nm]');legend('NA','ND');
+figure; plot(xmesh*1e7,dev.g0,'b',xmesh*1e7,dev.B,'r');
+ylabel('g0, B [cm^{-3}/s]'); xlabel('x [nm]'); legend('g0','B');
+
+%  Gradient properties
+figure; plot(xmesh*1e7,dev.gradEA,'r--',xmesh*1e7,dev.gradIP,'b-'); 
+ylabel('gradEA, gradIP (lin graded) [cm^{-3}/cm]'); xlabel('x [nm]');legend('gradEA','gradIP');
+figure; plot(xmesh*1e7,dev.gradNc,'r--',xmesh*1e7,dev.gradNv,'b-'); 
+ylabel('gradNc, gradNv (log graded) [cm^{-3}/cm]'); xlabel('x [nm]');legend('gradNc','gradNv');
+
+% Surface recombination velocity equivalence schemes
+figure; plot(xmesh*1e7,dev.mue,'b--',xmesh*1e7,dev.muh,'r--');
+ylabel('mue, muh [cm^{2}/Vs]'); xlabel('x [nm]');legend('mue','muh');
+figure; plot(xmesh*1e7,dev.taun,'b--',xmesh*1e7,dev.taup,'r--');
+ylabel('taun, taup [s]'); xlabel('x [nm]');legend('taun','taup');
+
+% Trap Density
+figure; plot(xmesh*1e7,dev.nt,'b--',xmesh*1e7,dev.pt,'r--');
+ylabel('nt, pt [cm^{-3}]'); xlabel('x [nm]');legend('nt','pt');
+
+figure; plot(xmesh*1e7,dev.ni_srh);
+ylabel('ni_{srh} [cm^{-3}]'); xlabel('x [nm]');
+
+figure; plot(xmesh*1e7,dev.int_switch);
+ylabel('int_{switch} [cm^{-3}]'); xlabel('x [nm]');
+
+


### PR DESCRIPTION
In some cases, the properties are not defined in the junction/interface in the excel file, for that reason I suggested to modify 'i' to "i-1". I have found that in some cases the mobility goes to infinite at the interface and pdepe claims that is not a good initial value due to the mobility and tau values. What I did is to let constant tau (as I commented in the scripts of 'surface_re_taun' taun= 1/sn(i)), and in build_device.m I put the mobility 'lin_graded'.
I have included Check_build_device_properties.m that includes the code to plot dev properties.
I used to run it before the end of build_device.m to check if the arrays of parameters are correct.