### PR TITLE
Remove odeset NonNegative option and removes t0 from MaxStep calculation

### DIFF
--- a/Core/df.m
+++ b/Core/df.m
@@ -176,7 +176,7 @@ ur_maxvar = zeros(N_max_variables, 1);
 
 %% Solver options
 % MaxStep = limit maximum time step size during integration
-options = odeset('MaxStep', par.MaxStepFactor*0.1*abs(par.tmax - par.t0), 'RelTol', par.RelTol, 'AbsTol', par.AbsTol);
+options = odeset('MaxStep', par.MaxStepFactor*0.1*par.tmax, 'RelTol', par.RelTol, 'AbsTol', par.AbsTol);
 
 %% Call solver
 % inputs with '@' are function handles to the subfunctions

--- a/Core/df.m
+++ b/Core/df.m
@@ -176,7 +176,7 @@ ur_maxvar = zeros(N_max_variables, 1);
 
 %% Solver options
 % MaxStep = limit maximum time step size during integration
-options = odeset('MaxStep', par.MaxStepFactor*0.1*abs(par.tmax - par.t0), 'RelTol', par.RelTol, 'AbsTol', par.AbsTol, 'NonNegative', [1,1,1,0]);
+options = odeset('MaxStep', par.MaxStepFactor*0.1*abs(par.tmax - par.t0), 'RelTol', par.RelTol, 'AbsTol', par.AbsTol);
 
 %% Call solver
 % inputs with '@' are function handles to the subfunctions


### PR DESCRIPTION
Fixes #62 
Closes #70
See the other 2 tickets for the discussion.
Sorry for fixing the two things in one pull request, but the edits are on the same line so conflicts would be very likely if fixed separately.