### PR TITLE
Better factor replacing eppmax in dfpde

### DIFF
--- a/Core/df.m
+++ b/Core/df.m
@@ -89,7 +89,6 @@ gradNv = device.gradNv;     % Valence band effective density of states gradient
 gradEA = device.gradEA;     % Electron Affinity gradient
 gradIP = device.gradIP;     % Ionisation Potential gradient
 epp = device.epp;           % Dielectric constant
-eppmax = max(par.epp);      % Maximum dielectric constant (for normalisation)
 B = device.B;               % Radiative recombination rate coefficient
 ni = device.ni;             % Intrinsic carrier density
 taun = device.taun;         % Electron SRH time constant
@@ -271,7 +270,7 @@ end
         C = [C_V; C_n; C_p; C_c; C_a];
         
         % Flux terms
-        F_V = (epp(i)/eppmax)*dVdx;
+        F_V = (epp(i)/1e6)*dVdx;
         F_n = mu_n(i)*n*(-dVdx + gradEA(i)) + (G_n*mu_n(i)*kB*T*(dndx - ((n/Nc(i))*gradNc(i))));
         F_p = mu_p(i)*p*(dVdx - gradIP(i)) + (G_p*mu_p(i)*kB*T*(dpdx - ((p/Nv(i))*gradNv(i))));
         F_c = mu_c(i)*(z_c*c*dVdx + kB*T*(dcdx + (c*(dcdx/(c_max(i) - c)))));
@@ -292,7 +291,7 @@ end
         r_np = r_rad + r_srh + r_vsr;
         
         % Source terms
-        S_V = (q/(eppmax*epp0))*(-n + p - NA(i) + ND(i) + z_a*a + z_c*c - z_a*Nani(i) - z_c*Ncat(i));
+        S_V = (q/(1e6*epp0))*(-n + p - NA(i) + ND(i) + z_a*a + z_c*c - z_a*Nani(i) - z_c*Ncat(i));
         S_n = g - r_np;
         S_p = g - r_np;
         S_c = 0;


### PR DESCRIPTION
The need of having eppmax in dfpde was not well understood, but it was needed for avoiding some Matlab's numerical problem, see #78.
Far from understanding why this happens, I propose an alternative factor which keeps us much more far away from this problem.
I obtained this value (actually any value between 1e6 and 1e10 is equally good) monitoring the value of `nnz(J)*condest(J)` in daeic12 as explained in #78.