### PR TITLE
dfplot xmesh invert axis labels

### DIFF
--- a/Core/dfplot.m
+++ b/Core/dfplot.m
@@ -295,8 +295,8 @@ classdef dfplot
         function xmesh(sol)
             figure(11)
             plot(sol.x)
-            xlabel('Position [cm]')
-            ylabel('Point')
+            xlabel('Point')
+            ylabel('Position [cm]')
         end
 
         function Vx(varargin)


### PR DESCRIPTION
The axes labels in dfplot.xmesh are currently inverted.