### PR TITLE
verifyStabilization avoid matching last timepoint

### DIFF
--- a/Helper/verifyStabilization.m
+++ b/Helper/verifyStabilization.m
@@ -68,7 +68,7 @@ compare_log = [false, true, true, false, false];
 % break they break at the same time
 % using t(end) could get a time out of the solution when the computation broke before reaching the final time
 end_time = t_array(length(sol_matrix(:, 1, 1)));
-[~, time_index] = min(abs(t_array - time_fraction * end_time)); % get time mesh index at a specified percentage of maximum time reached
+time_index = find(t_array <= time_fraction * end_time, 1, 'last'); % get time mesh index at a specified percentage of maximum time reached
 
 % for each component of the solution verify that didn't change significantly over the requested time
 for i = 1:length(sol_matrix(1, 1, :))


### PR DESCRIPTION
In some cases, the `verifyStabilization` routine can compare the last time point with itself, resulting in a false positive.
For example, this happens in `equilibrate` where high values of time_fraction are used:
https://github.com/barnesgroupICL/Driftfusion/blob/8925506f0f36219aab4730c961835b6e699d133b/Protocols/equilibrate.m#L85
