### PR TITLE
stabilize estimate the needed time from mobility and thickness

### DIFF
--- a/Protocols/stabilize.m
+++ b/Protocols/stabilize.m
@@ -4,13 +4,13 @@ function steadystate_struct = stabilize(struct)
 % Syntax:  steadystate_struct = stabilize(struct)
 %
 % Inputs:
-%   STRUCT - a solution struct as created by PINDRIFT.
+%   STRUCT - a solution struct as created by DF.
 %
 % Outputs:
 %   STEADYSTATE_STRUCT - a solution struct that reached its steady state
 %
 % Example:
-%   ssol_i_1S_SR = stabilize(ssol_i_1S_SR);
+%   soleq_ion_stable = stabilize(soleq.ion);
 %     checks if a solution reached steady state and replaces it with its steady state condition
 %
 % Other m-files required: df, verifyStabilization
@@ -20,7 +20,7 @@ function steadystate_struct = stabilize(struct)
 % See also df, verifyStabilization.
 %
 %% LICENSE
-% Copyright (C) 2020  Philip Calado, Ilario Gelmetti, and Piers R. F. Barnes
+% Copyright (C) 2021  Philip Calado, Ilario Gelmetti, and Piers R. F. Barnes
 % Imperial College London
 % This program is free software: you can redistribute it and/or modify
 % it under the terms of the GNU Affero General Public License as published
@@ -28,50 +28,27 @@ function steadystate_struct = stabilize(struct)
 % (at your option) any later version.
 % 
 %% Start code
-% Author: Ilario Gelmetti, Ph.D. student, perovskite photovoltaics
-% Institute of Chemical Research of Catalonia (ICIQ)
-% Research Group Prof. Emilio Palomares
-% email address: iochesonome@gmail.com
-% Supervised by: Dr. Phil Calado, Dr. Piers Barnes, Prof. Jenny Nelson
-% Imperial College London
-% May 2018; Last revision: May 2018
-
 %------------- BEGIN CODE --------------
-
-% shortcut
-par = struct.par;
-
-% set tpoints, just a few ones are necessary here
-par.tpoints = 10;
-par.tmesh_type = 2; % log spaced time mesh
-
-%% estimate a good tmax
-% a tmax too short would make the solution look stable even
-% if it's not; too large and the simulation could fail
-min_tmax_ions = 10;
-min_tmax_freecharges = 1e-3;
-
-% if both mobilities are set
-if max(par.mu_c) && par.mu_n(1)
-    par.tmax = min([min_tmax_ions, par.tmax*1e4, 2^(-log10(max(par.mu_c))) / 10 + 2^(-log10(par.mu_n(1)))]);
-    min_tmax = min_tmax_ions;
-% if ionic mobility is zero but free charges mobility is set
-elseif par.mu_n(1)
-    par.tmax = min([min_tmax_freecharges, par.tmax*1e4, 2^(-log10(par.mu_n(1)))]);
-    min_tmax = min_tmax_freecharges;
-end
-
-par.t0 = par.tmax / 1e8;
-
-%% equilibrate until steady state
 
 % initialize the output as the input, if already stable it will stay like
 % this
 steadystate_struct = struct;
 
+% shortcut
+par_old = struct.par;
+par_new = par_old;
+
+% set tpoints, just a few ones are necessary here
+par_new.tpoints = 10;
+par_new.tmesh_type = 2; % log spaced time mesh
+
+%% estimate a good tmax
+% a tmax too short would make the solution look stable even
+% if it's not; too large and the simulation could fail
+
 forceStabilization = false;
 % checks if the input structure reached the final time point
-if size(steadystate_struct.u, 1) ~= steadystate_struct.par.tpoints
+if size(steadystate_struct.u, 1) ~= par_old.tpoints
     % in case the provided solution did not reach the final time point,
     % force stabilization
     forceStabilization = true;
@@ -79,9 +56,35 @@ end
 % check if the prefious step was run over sufficient time. In case it was
 % not, the solution could seem stable to verifyStabilization just because
 % the solution did not evolve much in a time that was very short
-if struct.par.tmax < par.tmax
+
+min_tmax_freecharges = max((par_old.d.^2)./(2*par_old.kB*par_old.T*min(par_old.mu_n, par_old.mu_p)));
+
+% if both mobilities are set
+if par_old.mobseti && par_old.N_ionic_species > 0
+    t_c_diff = (par_old.d.^2)./(2*par_old.kB*par_old.T*par_old.mu_c);
+    t_c_diff = max(t_c_diff(isfinite(t_c_diff)));
+    if par_old.N_ionic_species == 2
+        t_a_diff = (par_old.d.^2)./(2*par_old.kB*par_old.T*par_old.mu_a);
+        t_a_diff = max(t_a_diff(isfinite(t_a_diff)));
+        min_tmax = max(t_c_diff, t_a_diff);
+    else
+        min_tmax = t_c_diff;
+    end
+    par_new.tmax = min([min_tmax, min_tmax_freecharges, par_old.tmax*1e4]);
+% if ionic mobility is disabled just consider the free charges
+% characteristic time
+else
+    par_new.tmax = min(min_tmax_freecharges, par_old.tmax*1e4);
+    min_tmax = min_tmax_freecharges;
+end
+
+if par_old.tmax < min_tmax
     forceStabilization = true;
 end
+
+par_new.t0 = par_new.tmax / 1e8;
+
+%% equilibrate until steady state
 
 % the warnings are not needed here
 warning('off', 'Driftfusion:verifyStabilization');
@@ -89,29 +92,29 @@ warning('off', 'Driftfusion:verifyStabilization');
 i=0;
 while forceStabilization || ~verifyStabilization(steadystate_struct.u, steadystate_struct.t, 1e-3) % check stability
     i = i + 1;
-    if i > 10
-        warning('Driftfusion:stabilize', [mfilename ' - not stabile after 10 attempts, giving up.']);
+    if i > 20
+        warning('Driftfusion:stabilize', [mfilename ' - not stabile after 20 attempts, giving up.']);
         break
     end
 
-    disp([mfilename ' - Stabilizing ' inputname(1) ' over ' num2str(par.tmax) ' s with an applied voltage of ' num2str(par.Vapp) ' V']);
+    disp([mfilename ' - Stabilizing ' inputname(1) ' over ' num2str(par_new.tmax) ' s with an applied voltage of ' num2str(par_new.Vapp) ' V']);
     % every cycle starts from the last timepoint of the previous cycle
-    steadystate_struct = df(steadystate_struct, par);
+    steadystate_struct = df(steadystate_struct, par_new);
     if size(steadystate_struct.u, 1) ~= steadystate_struct.par.tpoints % simulation failed
         % if the stabilization breaks (does not reach the final time point), reduce the tmax
-        par.tmax = par.tmax / 10;
-        par.t0 = par.tmax / 1e8;
+        par_new.tmax = par_new.tmax / 10;
+        par_new.t0 = par_new.tmax / 1e8;
         forceStabilization = true;
-    elseif par.tmax < min_tmax % did not run yet up to minimum time
+    elseif par_new.tmax < min_tmax % did not run yet up to minimum time
         % if the simulation time was not enough, force next step
-        par.tmax = min(par.tmax * 5, 1e4);
-        par.t0 = par.tmax / 1e8;
+        par_new.tmax = par_new.tmax * 5;
+        par_new.t0 = par_new.tmax / 1e8;
         forceStabilization = true;
     else % normal run
         % each round, increase the simulation time by 5 times
         % (increasing it more quickly can cause some simulation to fail)
-        par.tmax = min(par.tmax * 5, 1e4);
-        par.t0 = par.tmax / 1e8;
+        par_new.tmax = par_new.tmax * 5;
+        par_new.t0 = par_new.tmax / 1e8;
         forceStabilization = false;
     end
 


### PR DESCRIPTION
The stabilize routine had hardcoded values for tmax that are reasonable with the default input files but don't work when simulating, for example, very large perovskite layers.
Here, the tmax is estimated adapting Phil's formula from here:
https://github.com/barnesgroupICL/Driftfusion/blob/940ed2e4165d601689941ff6c49b447d67fbfd4d/Protocols/jumptoV.m#L36

I am not sure that this formula is the best estimation, @barnesgroupICL could you suggest a better one if known?
Thanks!