### PR TITLE
Equilibrate v2

### DIFF
--- a/Protocols/equilibrate.m
+++ b/Protocols/equilibrate.m
@@ -92,7 +92,8 @@ par.SRHset = 1;
 % Characteristic diffusion time
 t_diff = (par.dcum0(end)^2)/(2*par.kB*par.T*min(min(par.mu_n), min(par.mu_p)));
 t_diff_norm = (par.dcum0(end)^2)/(2*par.kB*par.T);
-par.tmax = 100*t_diff_norm;
+
+par.tmax = 1000*t_diff_norm;
 par.t0 = par.tmax/1e6;
 
 %% Solution with mobility switched on


### PR DESCRIPTION
protocols doCV 
sol_CV = VappFunction(sol, 'sin', [V0, Vmax, Vmin, cycles, tmax/cycles], tmax, tpoints, 0);
if i change VappFunction 'tri' to 'sin' i`m getting error

Warning: Failure at t=0.000000e+00.  Unable to meet integration tolerances without reducing the step size below the smallest value allowed (7.905050e-323) at time t.

How can I fix
I'm trying to make a memristor sample.